### PR TITLE
reduced import nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python to LaTeX 
+# Python to LaTeX
 
 This is a module provides several method to parse data from Python to LaTeX.
 
@@ -10,32 +10,32 @@ Author:
 `pip install --upgrade python_to_latex`
 
 ## Usage examples:
-Below there are some small examples how to use the provided functions. Detailed explanation of each function can be found by using 
+Below there are some small examples how to use the provided functions. Detailed explanation of each function can be found by using
 
       import python_to_latex as p2l
       help(p2l.<function_name>)
-      
+
 ### Printing a matrix:
 
   ```python
-        import python_to_latex.python_to_latex as p2l
+        import python_to_latex as p2l
         import numpy as np
-        mat2lat(np.eye(2),matrix_style='bmatrix')
+        p2l.mat2lat(np.eye(2), matrix_style='bmatrix')
   ```
   This will print the code block below and return the string to produce it.
-    
+
   ```latex
      \begin{bmatrix}
-       1 &   0\\ 
-       0 &   1\\ 
+       1 &   0\\
+       0 &   1\\
      \end{bmatrix}
   ```
 
 ### Printing table output:
 
    ```python
-        import python_to_latex.python_to_latex as p2l
-        numeric_list_to_tabularx([[1,2,3],[4,5,6]],heading=['A','B','c'])
+        import python_to_latex as p2l
+        p2l.numeric_list_to_tabularx([[1,2,3],[4,5,6]], heading=['A','B','c'])
    ```
 
     The above code will print the code block below and return the string to produce it.
@@ -44,7 +44,7 @@ Below there are some small examples how to use the provided functions. Detailed 
         \begin{tabularx}{\linewidth}{S[table-auto-round,table-omit-exponent,fixed-exponent=0]S[table-auto-round,table-omit-exponent,fixed-exponent=0]S[table-auto-round,table-omit-exponent,fixed-exponent=0]} \toprule
         {A} & {B} & {C}\\ \midrule
         1 & 2 & 3\\
-        4 & 5 & 6\\\bottomrule 
+        4 & 5 & 6\\\bottomrule
         \end{tabularx}
   ```
 
@@ -52,29 +52,28 @@ Below there are some small examples how to use the provided functions. Detailed 
 
 
    ```python
-        import python_to_latex.python_to_latex as p2l
+        import python_to_latex as p2l
         import numpy as np
-        import matplotlib
         import matplotlib.pyplot as plt
-        
+
         x = np.arange(15)
-        y1 = 2*x
-        y2 = x+5
+        y1 = 2 * x
+        y2 = x + 5
         y3 = x
-    
-        fig1,plt1 = plt.subplots(nrows=1,ncols=2)
-        plt1[0].plot(x,y1)
-        plt1[0].plot(x,y2,'.',label="line a")
-        plt1[1].plot(x,y3,label="line 1")
-        plt1[0].set_ylabel('$\lambda_2$')
-        plt1[1].set_xlabel('$b$')
-        plt1[1].set_ylabel('$\lambda_N$')
-        plt1[1].set_xlabel('$N$')
+
+        fig1, plt1 = plt.subplots(nrows=1, ncols=2)
+        plt1[0].plot(x, y1)
+        plt1[0].plot(x, y2, ".", label="line a")
+        plt1[1].plot(x, y3, label="line 1")
+        plt1[0].set_ylabel("$\lambda_2$")
+        plt1[1].set_xlabel("$b$")
+        plt1[1].set_ylabel("$\lambda_N$")
+        plt1[1].set_xlabel("$N$")
         plt1[0].legend(loc=1)
         plt1[0].set_label("test")
         fig1.show()
-    
-        fig2pgf(fig1,"test",retain_color=True,retain_linestyle=True)
+
+        p2l.fig2pgf(fig1, "test", retain_color=True, retain_linestyle=True)
    ```
 
 The code above generates a simgle matplotlib figure and then saves that figure in PGF format in a file called test.tikz. The saved file can be loaded in LaTex.

--- a/python_to_latex/__init__.py
+++ b/python_to_latex/__init__.py
@@ -2,8 +2,10 @@
 This is a Python module that provides several functions to facilitate the inclusion of data produced in Python in a LaTex document
 
 """
-__authors__ = 'Sonja Stuedli'
-__author_emails__ = 'scythja@gmail.com'
-__version__ = '0.0.3'
+__authors__ = "Sonja Stuedli"
+__author_emails__ = "scythja@gmail.com"
+__version__ = "0.0.4"
 
-import python_to_latex
+from .python_to_latex import fig2pgf, mat2lat, numeric_list_to_tabularx
+
+__all__ = ["fig2pgf", "mat2lat", "numeric_list_to_tabularx"]

--- a/python_to_latex/python_to_latex.py
+++ b/python_to_latex/python_to_latex.py
@@ -10,36 +10,40 @@ import matplotlib
 import matplotlib.pyplot as plt
 from matplotlib import colors
 from scipy import linalg as la
-import itertools
 
-def mat2lat(matrix,matrix_style='ownmatrix',save_name=None,style=dict()):
+
+def mat2lat(matrix, matrix_style="ownmatrix", save_name=None, style=dict()):
     """
     Takes a vector or two dimensional array into a string that produces a latex matrix or vector for printing.
 
     Parameters
     ----------
 
-    matrix_style (String:ownmatrix): Selects the latex environment that is used. 
+    matrix_style (String:ownmatrix): Selects the latex environment that is used.
 
     save_name (String:None): give the file name that the output should be saved to. If None the string is printed instead.
 
-    style (dict:{'decimal_points':0,'cell_width':3}): formating style for all numbers in the matrix. Currenlty, the formatting will be done using: 
+    style (dict:{'decimal_points':0,'cell_width':3}): formating style for all numbers in the matrix. Currenlty, the formatting will be done using:
                :<cell_width>.<decimal_points>f
     """
     s = f"\\begin{{{ matrix_style}}}\n"
     decimal_points = f".{style.get('decimal_points',0)}f"
-    cell_width = str(style.get('cell_width',3+style.get('decimal_points',0)))
-    for l in matrix: 
-        s += " & ".join([f"{n:{cell_width}{decimal_points}}" for n in l]) 
-        s += "\\\\ \n" 
+    cell_width = str(style.get("cell_width", 3 + style.get("decimal_points", 0)))
+    for l in matrix:
+        s += " & ".join([f"{n:{cell_width}{decimal_points}}" for n in l])
+        s += "\\\\ \n"
     s += f"\end{{{matrix_style}}}\n"
 
     if save_name:
         file_name = str(save_name)
-        if (file_name.endswith('.dat')) or (file_name.endswith('.tab')) or (file_name.endswith('.tex')):
-            f = open(file_name,'w')
+        if (
+            (file_name.endswith(".dat"))
+            or (file_name.endswith(".tab"))
+            or (file_name.endswith(".tex"))
+        ):
+            f = open(file_name, "w")
         else:
-            f = open(file_name +'.tab','w')
+            f = open(file_name + ".tab", "w")
         f.write(s)
         f.close()
     else:
@@ -47,15 +51,17 @@ def mat2lat(matrix,matrix_style='ownmatrix',save_name=None,style=dict()):
     return s
 
 
-def numeric_list_to_tabularx(data,heading=None,exponent=0,row_heading=None,save_name=None):
+def numeric_list_to_tabularx(
+    data, heading=None, exponent=0, row_heading=None, save_name=None
+):
     """
-    Transforms two dimensional array into a string that produces a latex tabularx using siunitx for printing. 
+    Transforms two dimensional array into a string that produces a latex tabularx using siunitx for printing.
 
     For exaple:
     [[1,2,3],[4,5,6]] is transformed to a string that if printed yields:
     \begin{tabularx}{\linewidth}{S[table-auto-round,table-omit-exponent,fixed-exponent=0]S[table-auto-round,table-omit-exponent,fixed-exponent=0]S[table-auto-round,table-omit-exponent,fixed-exponent=0]} \toprule
     1 & 2 & 3\\
-    4 & 5 & 6\\\bottomrule 
+    4 & 5 & 6\\\bottomrule
     \end{tabularx}
 
     Parameters
@@ -65,7 +71,7 @@ def numeric_list_to_tabularx(data,heading=None,exponent=0,row_heading=None,save_
     \begin{tabularx}{\linewidth}{S[table-auto-round,table-omit-exponent,fixed-exponent=0]S[table-auto-round,table-omit-exponent,fixed-exponent=0]S[table-auto-round,table-omit-exponent,fixed-exponent=0]} \toprule
     {A} & {B} & {C}\\ \midrule
     1 & 2 & 3\\
-    4 & 5 & 6\\\bottomrule 
+    4 & 5 & 6\\\bottomrule
     \end{tabularx}
 
     exponent (int: 0): is an optional parameter used in the definition of the S column for fixed-exponent=<exponent>. Default is 0, to not use a fixed exponent use exponent=None
@@ -76,41 +82,68 @@ def numeric_list_to_tabularx(data,heading=None,exponent=0,row_heading=None,save_
 
     """
     # Add input checking that data is 2D array like; row_heading is either None or a list; heading is either None or a list, exponent is int or None
-    
-    s='\\begin{tabularx}{\linewidth}{'
+
+    s = "\\begin{tabularx}{\linewidth}{"
     init = True
     if row_heading is not None:
-        for row,row_start in zip(data,row_heading):
+        for row, row_start in zip(data, row_heading):
             if init:
-                s += 'X'
+                s += "X"
                 if exponent:
-                    s += f'S'*len(row) + '} \\toprule'
+                    s += f"S" * len(row) + "} \\toprule"
                 else:
-                    s += f'S[table-auto-round,table-omit-exponent,fixed-exponent={exponent}]'*len(row) + '} \\toprule'
+                    s += (
+                        f"S[table-auto-round,table-omit-exponent,fixed-exponent={exponent}]"
+                        * len(row)
+                        + "} \\toprule"
+                    )
                 if heading:
-                    s += '\n' + ' & ' + ' & '.join(['{'+str(entry)+'}' for entry in heading]) +'\\\\ \midrule'
+                    s += (
+                        "\n"
+                        + " & "
+                        + " & ".join(["{" + str(entry) + "}" for entry in heading])
+                        + "\\\\ \midrule"
+                    )
                 init = False
-            s += '\n' + row_start + ' & ' + ' & '.join([str(entry) for entry in row]) + '\\\\'
+            s += (
+                "\n"
+                + row_start
+                + " & "
+                + " & ".join([str(entry) for entry in row])
+                + "\\\\"
+            )
     else:
         for row in data:
             if init:
                 if exponent:
-                    s += f'S'*len(row) + '} \\toprule'
+                    s += f"S" * len(row) + "} \\toprule"
                 else:
-                    s += f'S[table-auto-round,table-omit-exponent,fixed-exponent={exponent}]'*len(row) + '} \\toprule'
+                    s += (
+                        f"S[table-auto-round,table-omit-exponent,fixed-exponent={exponent}]"
+                        * len(row)
+                        + "} \\toprule"
+                    )
                 if heading:
-                    s += '\n' + ' & '.join(['{'+str(entry)+'}' for entry in heading]) +'\\\\ \midrule'
+                    s += (
+                        "\n"
+                        + " & ".join(["{" + str(entry) + "}" for entry in heading])
+                        + "\\\\ \midrule"
+                    )
                 init = False
-            s += '\n' + ' & '.join([str(entry) for entry in row]) + '\\\\'
+            s += "\n" + " & ".join([str(entry) for entry in row]) + "\\\\"
 
-        s += '\\bottomrule \n \end{tabularx}'
+        s += "\\bottomrule \n \end{tabularx}"
 
     if save_name:
         file_name = str(save_name)
-        if (file_name.endswith('.dat')) or (file_name.endswith('.tab')) or (file_name.endswith('.tex')):
-            f = open(file_name,'w')
+        if (
+            (file_name.endswith(".dat"))
+            or (file_name.endswith(".tab"))
+            or (file_name.endswith(".tex"))
+        ):
+            f = open(file_name, "w")
         else:
-            f = open(file_name +'.tab','w')
+            f = open(file_name + ".tab", "w")
         f.write(s)
         f.close()
     else:
@@ -118,75 +151,100 @@ def numeric_list_to_tabularx(data,heading=None,exponent=0,row_heading=None,save_
     return s
 
 
-plot_linestyles = {'-':"solid",'None':"only marks","--":'dashed',"-.":'dashdotted',":":"dotted"}
-plot_markers = {'None':'no marks','.':"mark=*",'x':'mark=x','o':'mark=o','s':'mark=square'}
+plot_linestyles = {
+    "-": "solid",
+    "None": "only marks",
+    "--": "dashed",
+    "-.": "dashdotted",
+    ":": "dotted",
+}
+plot_markers = {
+    "None": "no marks",
+    ".": "mark=*",
+    "x": "mark=x",
+    "o": "mark=o",
+    "s": "mark=square",
+}
 
-def fig2pgf(fig,save_name=None,retain_color = False, retain_linestyle = False, retain_marker = True,plot_as_table=True,figure_options="grid",plot_options=None,line_options=None,add_labels=None,export_legend=False):
+
+def fig2pgf(
+    fig,
+    save_name=None,
+    retain_color=False,
+    retain_linestyle=False,
+    retain_marker=True,
+    plot_as_table=True,
+    figure_options="grid",
+    plot_options=None,
+    line_options=None,
+    add_labels=None,
+    export_legend=False,
+):
     """
-    Convert a figure to a pgf plot.
+     Convert a figure to a pgf plot.
 
-    Parameters
-    ----------
+     Parameters
+     ----------
 
-    save_name (String:None): give the file name that the picture should be saved. If None the string is printed instead.
-    retain_color (Bool:False):  keep the color given in the plot in the pgf plot as well
-    retain_linestyle (Bool:False): keep the line style chosen in plot in the pgf plot
-    retain_marker (Bool:True): keep the markers chosen in the plot in the pgf plot
-    plot_as_table (Bool:True): use the table input in the pgf plot. Sometimes this does not work then you can set it to false to force coordinate input, if the x or y coordinates are strings plot_as_table is set to False to avoid issues
-    figure_options (String:'grid') : give additional options that apply for the complete figure. This will be overwritten by plot and line options.
-    plot_options (Dict:None): give additional options that hold for a single subplot. Set a plot label such as <plt_1.set_label('label')> when drawing the plot. Then, options can be given as dictionary having the given label as key (String) and the options as value (String)
-    line_options (Dict:None): give additional options that hold for this line. Set a label for the line while plotting such as <plt_2[1].plot(x,y2,label="line 1")>. Then, options can be given as dictionary having the given label as key (String) and the options as value (String)
-    
-   add_labels (String: None): if not None a label is printed included for each plot. This can be references as \ref{pgfplot:<add_labels><line_number>}
+     save_name (String:None): give the file name that the picture should be saved. If None the string is printed instead.
+     retain_color (Bool:False):  keep the color given in the plot in the pgf plot as well
+     retain_linestyle (Bool:False): keep the line style chosen in plot in the pgf plot
+     retain_marker (Bool:True): keep the markers chosen in the plot in the pgf plot
+     plot_as_table (Bool:True): use the table input in the pgf plot. Sometimes this does not work then you can set it to false to force coordinate input, if the x or y coordinates are strings plot_as_table is set to False to avoid issues
+     figure_options (String:'grid') : give additional options that apply for the complete figure. This will be overwritten by plot and line options.
+     plot_options (Dict:None): give additional options that hold for a single subplot. Set a plot label such as <plt_1.set_label('label')> when drawing the plot. Then, options can be given as dictionary having the given label as key (String) and the options as value (String)
+     line_options (Dict:None): give additional options that hold for this line. Set a label for the line while plotting such as <plt_2[1].plot(x,y2,label="line 1")>. Then, options can be given as dictionary having the given label as key (String) and the options as value (String)
 
-    export_legend (Bool:False): if set true a second file is exported that will produce the legend. The name is save_name with the postfix _legend<0-99>, the legend will not be included in the figure file. If there are multiple plots the legend is exported for each plot. To use this option, the option 'legend as name=..' cannot be used in the figure or plot options.
+    add_labels (String: None): if not None a label is printed included for each plot. This can be references as \ref{pgfplot:<add_labels><line_number>}
 
-    Example usage: 
-    x = np.arange(15)
-    y1 = 2*x
-    y2 = x+5
-    y3 = x
+     export_legend (Bool:False): if set true a second file is exported that will produce the legend. The name is save_name with the postfix _legend<0-99>, the legend will not be included in the figure file. If there are multiple plots the legend is exported for each plot. To use this option, the option 'legend as name=..' cannot be used in the figure or plot options.
 
-    fig1,plt1 = plt.subplots(nrows=1,ncols=2)
-    plt1[0].plot(x,y1)
-    plt1[0].plot(x,y2,'.',label="line a")
-    plt1[1].plot(x,y3,label="line 1")
-    plt1[0].set_ylabel('$\lambda_2$')
-    plt1[1].set_xlabel('$b$')
-    plt1[1].set_ylabel('$\lambda_N$')
-    plt1[1].set_xlabel('$N$')
-    plt1[0].legend(loc=1)
-    plt1[0].set_label("test")
-    fig1.show()
+     Example usage:
+     x = np.arange(15)
+     y1 = 2*x
+     y2 = x+5
+     y3 = x
 
-    fig2pgf(fig1,"test",retain_color=True,retain_linestyle=True,line_options={"line a":"black,dashed"},plot_options={"test":"dashed"})
-   
- 
-    The main idea is to let pgfplot take care of most plotting styles. It relies on the following latex packages:
-    - pgfplots (load also library groupplots)
-    - xcolor 
-    
-    To set some common features use pgfplotsset, for example:
-    \pgfplotsset{
-    every axis plot post/.style={
-      line join=round, % make the corners nicer: possible round,bevel,miter
-      thick,
-    }
-    To select a color, linestyle, and marker cycling automatically. Use a cycle list, for example:
-    }
-    \pgfplotsset{
-    % initialize colors
-    % cycle list/Paired,
-    cycle list/Set1,
-    cycle list/.define={my lines}{solid, dotted, dashed, dashdotted, dashdotdotted},
-    cycle list/.define={my marks}{*,x,asterisk,o},
-    % combine it with marks and line styles:
-    cycle multiindex* list={
-    linestyles*\nextlist
-    mark list*\nextlist
-    Set1\nextlist
-    },
-    }
+     fig1,plt1 = plt.subplots(nrows=1,ncols=2)
+     plt1[0].plot(x,y1)
+     plt1[0].plot(x,y2,'.',label="line a")
+     plt1[1].plot(x,y3,label="line 1")
+     plt1[0].set_ylabel('$\lambda_2$')
+     plt1[1].set_xlabel('$b$')
+     plt1[1].set_ylabel('$\lambda_N$')
+     plt1[1].set_xlabel('$N$')
+     plt1[0].legend(loc=1)
+     plt1[0].set_label("test")
+     fig1.show()
+
+     fig2pgf(fig1,"test",retain_color=True,retain_linestyle=True,line_options={"line a":"black,dashed"},plot_options={"test":"dashed"})
+
+
+     The main idea is to let pgfplot take care of most plotting styles. It relies on the following latex packages:
+     - pgfplots (load also library groupplots)
+     - xcolor
+
+     To set some common features use pgfplotsset, for example:
+     \pgfplotsset{
+     every axis plot post/.style={
+       line join=round, % make the corners nicer: possible round,bevel,miter
+       thick,
+     }
+     To select a color, linestyle, and marker cycling automatically. Use a cycle list, for example:
+     }
+     \pgfplotsset{
+     % initialize colors
+     % cycle list/Paired,
+     cycle list/Set1,
+     cycle list/.define={my lines}{solid, dotted, dashed, dashdotted, dashdotdotted},
+     cycle list/.define={my marks}{*,x,asterisk,o},
+     % combine it with marks and line styles:
+     cycle multiindex* list={
+     linestyles*\nextlist
+     mark list*\nextlist
+     Set1\nextlist
+     },
+     }
 
     """
     # implement input checking:
@@ -205,14 +263,22 @@ def fig2pgf(fig,save_name=None,retain_color = False, retain_linestyle = False, r
     # add user provided options
     if figure_options:
         global_options += "    " + str(figure_options) + ",\n"
-    
+
     if len(ax) == 1:
         s_init = "\\begin{axis}[\n" + global_options
         s_start = ""
         s_exit = "\end{axis}\n"
     else:
-        row_number,column_number,index = ax[0].get_geometry()
-        s_init = "\\begin{groupplot}[group style={group size="+str(column_number) + " by " + str(row_number) +"},\n" + global_options + "    ]\n"
+        row_number, column_number, index = ax[0].get_geometry()
+        s_init = (
+            "\\begin{groupplot}[group style={group size="
+            + str(column_number)
+            + " by "
+            + str(row_number)
+            + "},\n"
+            + global_options
+            + "    ]\n"
+        )
 
         s_exit = "\end{groupplot}\n"
         s_start = "\\nextgroupplot[\n"
@@ -229,7 +295,7 @@ def fig2pgf(fig,save_name=None,retain_color = False, retain_linestyle = False, r
     for axis in ax:
 
         ## axis definition:
-        
+
         s += s_start
         # todo logarithmic scale for x or y using tikz options below
         # "xmode=log|normal,ymode=log|normal"
@@ -255,128 +321,194 @@ def fig2pgf(fig,save_name=None,retain_color = False, retain_linestyle = False, r
         # todo add other options from figure
         # add user options if available
         if plot_options:
-            option = plot_options.get(axis.get_label(),None)
+            option = plot_options.get(axis.get_label(), None)
             if option:
                 s += "    " + str(option) + "\n"
         s += "    ]\n"
 
         # add a legend file
         if export_legend:
-            s_legend.append("%This file was created by python_to_latex. \n\\begin{tikzpicture} \n")
+            s_legend.append(
+                "%This file was created by python_to_latex. \n\\begin{tikzpicture} \n"
+            )
             if retain_color:
                 s_legend[-1] += " REPLACE_COLORS \n"
             s_legend[-1] += "\\begin{axis}[%\n    " + str(figure_options) + ",\n"
             if plot_options:
-                option = plot_options.get(axis.get_label(),None)
+                option = plot_options.get(axis.get_label(), None)
                 if option:
                     s_legend[-1] += "    " + str(option) + "\n"
 
-            s_legend[-1] += "    hide axis,\n    legend image post style={sharp plot},\n    width=0.11cm,\n    height=0.1cm,\n"
+            s_legend[
+                -1
+            ] += "    hide axis,\n    legend image post style={sharp plot},\n    width=0.11cm,\n    height=0.1cm,\n"
             s_legend[-1] += "    ]\n"
-
 
         ## make legend_entries
         if axis.get_legend():
             legend_labels = [i.get_text() for i in axis.get_legend().texts]
             if export_legend:
-                s_legend[-1] += "\legend{" + ','.join(legend_labels) + "}\n"
-                s += "%\legend{" + ','.join(legend_labels) + "}\n"
+                s_legend[-1] += "\legend{" + ",".join(legend_labels) + "}\n"
+                s += "%\legend{" + ",".join(legend_labels) + "}\n"
             else:
-                s += "\legend{" + ','.join(legend_labels) + "}\n"
+                s += "\legend{" + ",".join(legend_labels) + "}\n"
 
         # add line plots.
-        for line_number,line in enumerate(axis.lines):
-               
+        for line_number, line in enumerate(axis.lines):
+
             s += "\\addplot +["
             # add necessary options
             if retain_linestyle:
-                linestyle = plot_linestyles.get(line.get_linestyle(),None)
+                linestyle = plot_linestyles.get(line.get_linestyle(), None)
                 if linestyle:
                     s += f"{linestyle},"
             if retain_color:
                 color_hex = line.get_color()
-                if not color_hex.startswith('#'):
+                if not color_hex.startswith("#"):
                     color_hex = colors.cnames[color_hex]
-                color_definitions.append("\definecolor{color"+str(len(color_definitions))+"}{RGB}{"+" , ".join([str(int(color_hex.lstrip('#')[i:i+2], 16)) for i in (0, 2, 4)])+"} ")
+                color_definitions.append(
+                    "\definecolor{color"
+                    + str(len(color_definitions))
+                    + "}{RGB}{"
+                    + " , ".join(
+                        [
+                            str(int(color_hex.lstrip("#")[i : i + 2], 16))
+                            for i in (0, 2, 4)
+                        ]
+                    )
+                    + "} "
+                )
                 s += f"color{str(len(color_definitions)-1)},"
             if retain_marker:
-                markers = plot_markers.get(line.get_marker(),None)
+                markers = plot_markers.get(line.get_marker(), None)
                 if markers:
                     s += f"{markers},"
             # add additional user options
             if line_options:
-                s += str(line_options.get(line.get_label(),'')) 
+                s += str(line_options.get(line.get_label(), ""))
             s += "]\n"
 
-            if len(line.get_xdata())==2 and line.get_xdata()[0] == 0 and line.get_xdata()[1] == 1 and line.get_ydata()[0] == line.get_ydata()[1]:
+            if (
+                len(line.get_xdata()) == 2
+                and line.get_xdata()[0] == 0
+                and line.get_xdata()[1] == 1
+                and line.get_ydata()[0] == line.get_ydata()[1]
+            ):
                 # This is a horizontal line
-                s += "coordinates{" + f"({axis.get_xlim()[0]},{line.get_ydata()[0]}) \n ({axis.get_xlim()[1]},{line.get_ydata()[1]})" + "};\n"
-            elif len(line.get_ydata())==2 and line.get_ydata()[0] == 0 and line.get_ydata()[1] == 1 and line.get_xdata()[0] == line.get_xdata()[1]:
+                s += (
+                    "coordinates{"
+                    + f"({axis.get_xlim()[0]},{line.get_ydata()[0]}) \n ({axis.get_xlim()[1]},{line.get_ydata()[1]})"
+                    + "};\n"
+                )
+            elif (
+                len(line.get_ydata()) == 2
+                and line.get_ydata()[0] == 0
+                and line.get_ydata()[1] == 1
+                and line.get_xdata()[0] == line.get_xdata()[1]
+            ):
                 # This is a vertical line
-                s += "coordinates{" + f"({line.get_xdata()[0]},{axis.get_ylim()[0]}) \n ({line.get_xdata()[1]},{axis.get_ylim()[1]})" + "};\n"
+                s += (
+                    "coordinates{"
+                    + f"({line.get_xdata()[0]},{axis.get_ylim()[0]}) \n ({line.get_xdata()[1]},{axis.get_ylim()[1]})"
+                    + "};\n"
+                )
             else:
                 # This is any other line
-                if plot_as_table :
-                    s+= " table{%\n" +"\n".join([f"  {x} {y}" for (x,y) in zip(line.get_xdata(),line.get_ydata())]) + "\n};\n"
+                if plot_as_table:
+                    s += (
+                        " table{%\n"
+                        + "\n".join(
+                            [
+                                f"  {x} {y}"
+                                for (x, y) in zip(line.get_xdata(), line.get_ydata())
+                            ]
+                        )
+                        + "\n};\n"
+                    )
                 else:
                     if symbolic_x_coordinates:
-                        [symbolic_x_coordinates.append(str(label)) for label in line.get_xdata() if label not in symbolic_x_coordinates]
+                        [
+                            symbolic_x_coordinates.append(str(label))
+                            for label in line.get_xdata()
+                            if label not in symbolic_x_coordinates
+                        ]
                     if symbolic_y_coordinates:
-                        [symbolic_y_coordinates.append(str(label)) for label in line.get_ydata() if label not in symbolic_y_coordinates]
-                    s+= " coordinates{%\n" +"\n".join([f"  ({x},{y})" for (x,y) in zip(line.get_xdata(),line.get_ydata())]) + "\n};\n"
+                        [
+                            symbolic_y_coordinates.append(str(label))
+                            for label in line.get_ydata()
+                            if label not in symbolic_y_coordinates
+                        ]
+                    s += (
+                        " coordinates{%\n"
+                        + "\n".join(
+                            [
+                                f"  ({x},{y})"
+                                for (x, y) in zip(line.get_xdata(), line.get_ydata())
+                            ]
+                        )
+                        + "\n};\n"
+                    )
 
             if add_labels:
-                  s += f"\label{{pgfplot:{add_labels}{line_number}}}"
+                s += f"\label{{pgfplot:{add_labels}{line_number}}}"
 
             if export_legend:
                 s_legend[-1] += "\\addplot +["
                 if retain_linestyle:
-                    linestyle = plot_linestyles.get(line.get_linestyle(),None)
+                    linestyle = plot_linestyles.get(line.get_linestyle(), None)
                     if linestyle:
                         s_legend[-1] += f"{linestyle},"
                 if retain_color:
                     s_legend[-1] += f"color{str(len(color_definitions)-1)},"
                 if retain_marker:
-                    markers = plot_markers.get(line.get_marker(),None)
+                    markers = plot_markers.get(line.get_marker(), None)
                     if markers:
                         s_legend[-1] += f"{markers},"
                 if line_options:
-                    s_legend[-1] += str(line_options.get(line.get_label(),''))
+                    s_legend[-1] += str(line_options.get(line.get_label(), ""))
                 s_legend[-1] += "]"
                 s_legend[-1] += "coordinates {(0,0)};\n"
 
         if export_legend:
             if retain_color:
-                s_legend[-1] = s_legend[-1].replace("REPLACE_COLORS","\n ".join(color_definitions)) + "\n"
+                s_legend[-1] = (
+                    s_legend[-1].replace(
+                        "REPLACE_COLORS", "\n ".join(color_definitions)
+                    )
+                    + "\n"
+                )
             s_legend[-1] += "\end{axis}\n\end{tikzpicture} \n"
 
     if retain_color:
-        s=s.replace("REPLACE_COLORS","\n ".join(color_definitions)) + "\n"
+        s = s.replace("REPLACE_COLORS", "\n ".join(color_definitions)) + "\n"
 
     if symbolic_x_coordinates:
-        s=s.replace("REPLACE_SYMBOLIC_COORDS_X",",".join(symbolic_x_coordinates)) 
+        s = s.replace("REPLACE_SYMBOLIC_COORDS_X", ",".join(symbolic_x_coordinates))
     if symbolic_y_coordinates:
-        s=s.replace("REPLACE_SYMBOLIC_COORDS_Y",",".join(symbolic_y_coordinates)) 
-
+        s = s.replace("REPLACE_SYMBOLIC_COORDS_Y", ",".join(symbolic_y_coordinates))
 
     # finish string
     s += s_exit + "\end{tikzpicture} \n"
 
     if save_name:
         file_name = str(save_name)
-        if (file_name.endswith('.tikz')) or (file_name.endswith('.pgf')) or (file_name.endswith('.tex')):
-            f = open(file_name,'w')
+        if (
+            (file_name.endswith(".tikz"))
+            or (file_name.endswith(".pgf"))
+            or (file_name.endswith(".tex"))
+        ):
+            f = open(file_name, "w")
             if export_legend:
-                for idx,legend_string in enumerate(s_legend):
-                    f_name = file_name.replace('.',"_legend"+str(idx)+'.')
-                    f_legend = open(f_name,'w')
+                for idx, legend_string in enumerate(s_legend):
+                    f_name = file_name.replace(".", "_legend" + str(idx) + ".")
+                    f_legend = open(f_name, "w")
                     f_legend.write(legend_string)
-                    f_legend.close()              
+                    f_legend.close()
         else:
-            f = open(file_name +'.tikz','w')
+            f = open(file_name + ".tikz", "w")
             if export_legend:
-                for idx,legend_string in enumerate(s_legend):
-                    f_legend = open(file_name+"_legend"+str(idx)+'.tikz','w')
+                for idx, legend_string in enumerate(s_legend):
+                    f_legend = open(file_name + "_legend" + str(idx) + ".tikz", "w")
                     f_legend.write(legend_string)
                     f_legend.close()
         f.write(s)
@@ -384,4 +516,3 @@ def fig2pgf(fig,save_name=None,retain_color = False, retain_linestyle = False, r
     else:
         print(s)
     return s
-

--- a/setup.py
+++ b/setup.py
@@ -4,25 +4,25 @@ import pathlib
 here = pathlib.Path(__file__).parent.resolve()
 
 # Get the long description from the README file
-long_description = (here / 'README.md').read_text(encoding='utf-8')
+long_description = (here / "README.md").read_text(encoding="utf-8")
 
 
 import python_to_latex as p2l
 
 
 setup(
-    name='python_to_latex',
+    name="python_to_latex",
     version=p2l.__version__,
-    description='Python module to facilitate input in LaTex from Python scripts',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    #long_description=long_description,
+    description="Python module to facilitate input in LaTex from Python scripts",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    long_description=long_description,
     author=p2l.__authors__,
     author_email=p2l.__author_emails__,
-    url='https://github.com/scythja123/TODO',
-    license= 'GPLv3',
+    url="https://github.com/scythja123/TODO",
+    license="GPLv3",
     packages=find_packages(where=here),
     install_requires=[],
-    python_requires='>=3',
-    platforms=['any']
+    python_requires=">=3",
+    platforms=["any"],
 )


### PR DESCRIPTION
, added __all__ for module, updated README exma…mples, formatted code with black.

Generally, it will now be possible to do `from python_to_latex import *` to import only the 3 functions, and also `import python_to_latex as p2l` to use the functions directly.

The rest of the changes is just reformatting the code with PEP-8 compliant `black` formatter.